### PR TITLE
Style guide conformity

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/lib/rspec-mail-matchers/version.rb
+++ b/lib/rspec-mail-matchers/version.rb
@@ -1,7 +1,7 @@
 module Rspec
   module Mail
     module Matchers
-      VERSION = "0.0.1"
+      VERSION = '0.0.1'
     end
   end
 end

--- a/rspec-mail-matchers.gemspec
+++ b/rspec-mail-matchers.gemspec
@@ -4,20 +4,20 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rspec-mail-matchers/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "rspec-mail-matchers"
+  spec.name          = 'rspec-mail-matchers'
   spec.version       = Rspec::Mail::Matchers::VERSION
-  spec.authors       = ["Ed Robinson"]
-  spec.email         = ["ed.robinson@reevoo.com"]
-  spec.summary       = %q{ RSpec Matchers for the Mail gem}
-  spec.homepage      = "http://reevoo.github.io"
-  spec.license       = "MIT"
+  spec.authors       = ['Ed Robinson']
+  spec.email         = ['ed.robinson@reevoo.com']
+  spec.summary       = ' RSpec Matchers for the Mail gem'
+  spec.homepage      = 'http://reevoo.github.io'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "rspec-expectations", "> 2.11"
-  spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_development_dependency "rake"
+  spec.add_dependency 'rspec-expectations', '> 2.11'
+  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Rubocop is still moaning about the fact that `lib/rspec-mail-matchers.rb` doesn't use snake case.
